### PR TITLE
test for evp_aes_ctr_mt to determine whether to set OPENSSL_HAVE_EVPCTR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2499,7 +2499,8 @@ if test "x$openssl" = "xyes" ; then
 		]], [[
 		exit(EVP_aes_128_ctr() == NULL ||
 		    EVP_aes_192_cbc() == NULL ||
-		    EVP_aes_256_cbc() == NULL);
+		    EVP_aes_256_cbc() == NULL ||
+		    evp_aes_ctr_mt() == NULL);
 		]])],
 		[
 			AC_MSG_RESULT([yes])


### PR DESCRIPTION
Currently the configure script tests for EVP_aes_???_cbc to decide if it
should set OPENSSL_HAVE_EVPCTR. With openssl-1.0.2 these pass, but
compile fails because evp_aes_ctr_mt is missing. This makes the
configure script also check for this function.