### PR TITLE
Hpn upstream fixes

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -1948,7 +1948,7 @@ client_request_agent(const char *request_type, int rchan)
 	else
 	c = channel_new("authentication agent connection",
 	    SSH_CHANNEL_OPEN, sock, sock, -1,
-	    options.hpn_buffer_size, options.hpn_buffer_size, 0,
+	    options.hpn_buffer_size, CHAN_TCP_PACKET_DEFAULT, 0,
 	    "authentication agent connection", 1);
 	c->force_drain = 1;
 	return c;

--- a/clientloop.c
+++ b/clientloop.c
@@ -1943,7 +1943,7 @@ client_request_agent(const char *request_type, int rchan)
 	if (options.hpn_disabled)
 	c = channel_new("authentication agent connection",
 	    SSH_CHANNEL_OPEN, sock, sock, -1,
-		    CHAN_X11_WINDOW_DEFAULT, CHAN_TCP_WINDOW_DEFAULT, 0,
+		    CHAN_X11_WINDOW_DEFAULT, CHAN_TCP_PACKET_DEFAULT, 0,
 		    "authentication agent connection", 1);
 	else
 	c = channel_new("authentication agent connection",

--- a/ssh.c
+++ b/ssh.c
@@ -1907,7 +1907,7 @@ ssh_session2_open(void)
 
 	packetmax = CHAN_SES_PACKET_DEFAULT;
 	if (tty_flag) {
-		window = 4*CHAN_SES_PACKET_DEFAULT;
+		window = CHAN_SES_WINDOW_DEFAULT;
 		window >>= 1;
 		packetmax >>= 1;
 	}


### PR DESCRIPTION
A few values were wrongly being copied from each HPN patch after they were changed upstream.