### PR TITLE
Use an exit flag as well as pthread_cancel to tell worker threads to terminate

### DIFF
--- a/cipher-ctr-mt.c
+++ b/cipher-ctr-mt.c
@@ -421,8 +421,14 @@ ssh_aes_ctr_init(EVP_CIPHER_CTX *ctx, const u_char *key, const u_char *iv,
 		/* Cancel pregen threads */
 		for (i = 0; i < CIPHER_THREADS; i++)
 			pthread_cancel(c->tid[i]);
+		for (i = 0; i < NUMKQ; i++) {
+			pthread_mutex_lock(&c->q[i].lock);
+			pthread_cond_broadcast(&c->q[i].cond);
+			pthread_mutex_unlock(&c->q[i].lock);
+		}
 		for (i = 0; i < CIPHER_THREADS; i++)
 			pthread_join(c->tid[i], NULL);
+
 		/* Start over getting key & iv */
 		c->state = HAVE_NONE;
 	}

--- a/cipher-ctr-mt.c
+++ b/cipher-ctr-mt.c
@@ -141,7 +141,7 @@ struct ssh_aes_ctr_ctx
 	STATS_STRUCT(stats);
 	u_char		aes_counter[AES_BLOCK_SIZE];
 	pthread_t	tid[CIPHER_THREADS];
-	pthread_rwlock_t thread_lock;
+	pthread_rwlock_t tid_lock;
 	int		state;
 	int		qidx;
 	int		ridx;
@@ -213,9 +213,9 @@ thread_loop(void *x)
 	/* Thread local copy of AES key */
 	memcpy(&key, &c->aes_ctx, sizeof(key));
 
-	pthread_rwlock_rdlock(&c->thread_lock);
+	pthread_rwlock_rdlock(&c->tid_lock);
 	first_tid = c->tid[0];
-	pthread_rwlock_unlock(&c->thread_lock);
+	pthread_rwlock_unlock(&c->tid_lock);
 
 	/*
 	 * Handle the special case of startup, one thread must fill
@@ -405,7 +405,7 @@ ssh_aes_ctr_init(EVP_CIPHER_CTX *ctx, const u_char *key, const u_char *iv,
 
 	if ((c = EVP_CIPHER_CTX_get_app_data(ctx)) == NULL) {
 		c = xmalloc(sizeof(*c));
-		pthread_rwlock_init(&c->thread_lock, NULL);
+		pthread_rwlock_init(&c->tid_lock, NULL);
 
 		c->state = HAVE_NONE;
 		for (i = 0; i < NUMKQ; i++) {
@@ -459,9 +459,9 @@ ssh_aes_ctr_init(EVP_CIPHER_CTX *ctx, const u_char *key, const u_char *iv,
 		/* Start threads */
 		for (i = 0; i < CIPHER_THREADS; i++) {
 			debug("spawned a thread");
-			pthread_rwlock_wrlock(&c->thread_lock);
+			pthread_rwlock_wrlock(&c->tid_lock);
 			pthread_create(&c->tid[i], NULL, thread_loop, c);
-			pthread_rwlock_unlock(&c->thread_lock);
+			pthread_rwlock_unlock(&c->tid_lock);
 		}
 		pthread_mutex_lock(&c->q[0].lock);
 		while (c->q[0].qstate == KQINIT)
@@ -503,9 +503,9 @@ ssh_aes_ctr_thread_reconstruction(EVP_CIPHER_CTX *ctx)
 	/* reconstruct threads */
 	for (i = 0; i < CIPHER_THREADS; i++) {
 		debug("spawned a thread");
-		pthread_rwlock_wrlock(&c->thread_lock);
+		pthread_rwlock_wrlock(&c->tid_lock);
 		pthread_create(&c->tid[i], NULL, thread_loop, c);
-		pthread_rwlock_unlock(&c->thread_lock);
+		pthread_rwlock_unlock(&c->tid_lock);
 	}
 }
 

--- a/cipher-ctr-mt.c
+++ b/cipher-ctr-mt.c
@@ -127,7 +127,7 @@ struct kq {
 	u_char		keys[KQLEN][AES_BLOCK_SIZE];
 	u_char		ctr[AES_BLOCK_SIZE];
 	u_char		pad0[CACHELINE_LEN];
-	volatile int	qstate;
+	int		qstate;
 	pthread_mutex_t	lock;
 	pthread_cond_t	cond;
 	u_char		pad1[CACHELINE_LEN];


### PR DESCRIPTION
It turns out that OSX's pthread_cancel implementation is not very reliable, so this switches to a flag variable rather than using pthread_cancel to tell threads that they should exit.

This also removes the volatile keyword from the qstate variable. It's not necessary since the variable is always protected by a mutex, and it causes the compiler to not be able to optimize properly.
