### PR TITLE
increase default HPN Buffer Size

### DIFF
--- a/HPN-README
+++ b/HPN-README
@@ -32,10 +32,10 @@ http://www.psc.edu/networking/projects/hpn-ssh
 BUFFER SIZES:
 
 If HPN is disabled the receive buffer size will be set to the
-OpenSSH default of 64K.
+OpenSSH default of 2MB.
 
 If an HPN system connects to a nonHPN system the receive buffer will
-be set to the HPNBufferSize value. The default is 2MB but user adjustable.
+be set to the HPNBufferSize value. The default is 4MB but user adjustable.
 
 If an HPN to HPN connection is established a number of different things might
 happen based on the user options and conditions.

--- a/channels.c
+++ b/channels.c
@@ -191,7 +191,7 @@ static void channel_connect_ctx_free(struct channel_connect *);
 
 
 static int hpn_disabled = 0;
-static int hpn_buffer_size = 2 * 1024 * 1024;
+static int hpn_buffer_size = 4 * 1024 * 1024;
 
 /* -- channel core */
 

--- a/ssh.c
+++ b/ssh.c
@@ -1925,7 +1925,7 @@ hpn_options_init(void)
 	if (tty_flag)
 		options.hpn_buffer_size = CHAN_SES_WINDOW_DEFAULT;
 	else
-		options.hpn_buffer_size = 2 * 1024 * 1024;
+		options.hpn_buffer_size = 4 * 1024 * 1024;
 
 	if (datafellows & SSH_BUG_LARGEWINDOW) {
 		debug("HPN to Non-HPN Connection");


### PR DESCRIPTION
CHAN_SES_WINDOW_DEFAULT is now 2mb, so increase the HPN buffer to once again be larger than the default