### PR TITLE
HPN-README: Mention correct OpenSSH buffer size

### DIFF
--- a/HPN-README
+++ b/HPN-README
@@ -32,7 +32,7 @@ http://www.psc.edu/networking/projects/hpn-ssh
 BUFFER SIZES:
 
 If HPN is disabled the receive buffer size will be set to the
-OpenSSH default of 64K.
+OpenSSH default of 2MB (for OpenSSH versions before 4.7: 64KB).
 
 If an HPN system connects to a nonHPN system the receive buffer will
 be set to the HPNBufferSize value. The default is 2MB but user adjustable.


### PR DESCRIPTION
It was changed from 64 KB to 2 MB in 2007:

https://github.com/openssh/openssh-portable/commit/395ecc2bdeefd86a31562dd4145f370b816814bd

Without this fix, the current HPN-README is quite confusing.

This also addresses the doc part of #11.