### PR TITLE
Alpine linux: __linux__ def

### DIFF
--- a/Dockerfile_alpine_x86
+++ b/Dockerfile_alpine_x86
@@ -1,0 +1,43 @@
+FROM alpine:3.12
+USER root
+
+# -- build & hpn-ssh
+WORKDIR /hpnssh
+COPY hpnssh /hpnssh
+
+RUN apk add \
+  bash \
+  openrc \
+  build-base \
+  musl-dev \
+  linux-headers \
+  curl \
+  gcc \
+  g++ \
+  autoconf \
+  automake \
+  zlib-dev \
+  openssl-dev \
+  libc-dev \
+  coreutils \
+  dumb-init \
+  gettext \
+  sudo
+
+# hpn-ssh build
+RUN autoreconf -f -i
+RUN CFLAGS="-D__alpine__" ./configure 
+RUN make && make install
+# RUN useradd --system --shell /usr/sbin/nologin --comment="Privilege separated HPNSSH User" --home=/run/hpnsshd hpnsshd
+RUN adduser -D -H -u 1001 -s /usr/sbin/nologin -h /run/hpnsshd -g "Privilege separated HPNSSH User" hpnsshd
+EXPOSE 2222
+
+CMD ["openresty", "-g", "daemon off;"]
+
+# RUN adduser -D -H -s /sbin/nologin -h /run/hpnsshd -g "Privilege separated HPNSSH User" hpnsshd
+
+RUN chmod +x /entrypoint.sh /refresh-certificate.sh /refresh-configuration.sh /ssh-proxy.sh /ip-whitelist.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/usr/local/sbin/hpnsshd"]

--- a/Dockerfile_deb_arm
+++ b/Dockerfile_deb_arm
@@ -1,0 +1,46 @@
+FROM debian:bullseye
+
+# -- install dependencies to build hpn-ssh lib
+RUN apt-get update && \
+    apt-get install -y  build-essential \ 
+                        zlib1g-dev \
+                        libssl-dev \ 
+                        libreadline-dev \ 
+                        autoconf \
+                        automake \
+                        # -- optional
+                        sudo \
+                        less \
+                        htop
+
+# -- copy source code from git
+COPY openssh-portable /app
+WORKDIR /app
+
+# -- configure build
+RUN autoreconf -f -i
+RUN ./configure  
+      # --prefix=/usr \
+      # --exec_prefix=/usr \
+      # --sbindir=/usr/bin \
+      # --libexecdir=/usr/lib/hpnssh \ 
+      # --with-privsep-path=/var/empty/sshd \
+      # --sysconfdir=/etc
+
+# -- setup hpnsshd user
+# https://www.psc.edu/hpn-ssh-home/hpn-ssh-installation/#step-8-set-up-the-hpnsshd-user
+RUN useradd --system --shell /usr/sbin/nologin --comment="Privilege separated HPNSSH User" --home=/run/hpnsshd hpnsshd
+
+# -- make & install
+RUN make && make install
+
+# -- add testing user
+RUN useradd -rm -d /home/test -s /bin/bash -g root -G sudo -u 1000 test
+RUN echo 'test:test' | chpasswd
+
+# -- hpnssh default port is 2222
+EXPOSE 2222
+
+# -- start hpn-ssh daemon
+CMD ["/usr/local/sbin/hpnsshd", "-D"]
+

--- a/Dockerfile_deb_x86
+++ b/Dockerfile_deb_x86
@@ -1,0 +1,45 @@
+FROM debian:bullseye AS builder
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  gcc \
+  g++ \
+  libc6-dev \
+  libssl-dev \ 
+  autoconf \
+  automake \
+  zlib1g-dev
+
+# -- copy source code from git
+COPY openssh-portable /app
+WORKDIR /app
+
+# -- configure build
+RUN CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++
+RUN autoreconf -f -i
+RUN ./configure \ 
+#  --prefix=/hpnssh_output 
+# --prefix=/usr \
+# --exec_prefix=/usr \
+# --sbindir=/usr/bin \
+# --libexecdir=/usr/lib/hpnssh \ 
+# --with-privsep-path=/var/empty/sshd \
+# --sysconfdir=/etc
+
+# -- setup hpnsshd user
+# -- https://www.psc.edu/hpn-ssh-home/hpn-ssh-installation/#step-8-set-up-the-hpnsshd-user
+RUN useradd --system --shell /usr/sbin/nologin --comment="Privilege separated HPNSSH User" --home=/run/hpnsshd hpnsshd
+
+# -- make & install
+RUN make && make install
+
+# -- add testing user
+RUN useradd -rm -d /home/test -s /bin/bash -g root -G sudo -u 1000 test
+RUN echo 'test:test' | chpasswd
+
+# -- hpnssh default port is 2222
+EXPOSE 2222
+
+# -- start hpn-ssh daemon
+CMD ["/usr/local/sbin/hpnsshd", "-D"]
+

--- a/metrics.c
+++ b/metrics.c
@@ -2,7 +2,10 @@
 #include "metrics.h"
 #include "ssherr.h"
 #include <stdlib.h>
-#ifdef __linux__
+#ifdef __alpine__
+#include <stdio.h>
+#endif
+#if defined __linux__ && !defined(__alpine__)
 #include <linux/version.h>
 #endif
 
@@ -28,7 +31,7 @@ metrics_write_binn_object(struct tcp_info *data, struct binn_struct *binnobj) {
  * on non linux systems we set the kernel version to 0
  * which will get us the base set of metrics from netinet/tcp.h
  */
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 	binn_object_set_uint32(binnobj, "kernel_version", LINUX_VERSION_CODE);
 #else
 	binn_object_set_uint32(binnobj, "kernel_version", 0);
@@ -63,7 +66,7 @@ metrics_write_binn_object(struct tcp_info *data, struct binn_struct *binnobj) {
 			       data->tcpi_rcv_space);
 
 /* the following exist under both but with different names */
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 	binn_object_set_uint8(binnobj, "tcpi_ca_state",
 			      data->tcpi_ca_state);
 	binn_object_set_uint8(binnobj, "tcpi_probes",
@@ -140,7 +143,7 @@ metrics_write_binn_object(struct tcp_info *data, struct binn_struct *binnobj) {
 #endif
 
 /* Under BSD snd_rexmitpack is the same as linux total_retrans*/
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 	binn_object_set_uint32(binnobj, "tcpi_total_retrans",
 			       data->tcpi_total_retrans);
 #else
@@ -149,7 +152,7 @@ metrics_write_binn_object(struct tcp_info *data, struct binn_struct *binnobj) {
 #endif
 
 /* The last section are for kernel specific metrics in linux */
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
 	binn_object_set_uint64(binnobj, "tcpi_max_pacing_rate",
 			       data->tcpi_max_pacing_rate);
@@ -285,7 +288,7 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	 * any given metric. This means that a remote host that has a different
 	 * kernel that the local host will be able to process the data in terms of
 	 * the remote kernel version. Only necessary under linux*/
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 	if (kernel_version >= KERNEL_VERSION(3,15,0)) {
 		len += snprintf(*output+len, (buflen-len), ", %llu, %llu",
 				binn_object_uint64(binnobj, "tcpi_max_pacing_rate"),
@@ -381,7 +384,7 @@ metrics_print_header(FILE *fptr, char *extra_text, int kernel_version) {
 	/* compare the received kernel version to the version that supports
 	 * any given metric. This way we can print consistent headers.
 	 * Only necessary under linux*/
-#ifdef __linux__
+#if defined __linux__ && !defined(__alpine__)
 	if (kernel_version >= KERNEL_VERSION(3,15,0)) {
 		fprintf(fptr, ", max_pacing_rate, pacing_rate");
 	}

--- a/metrics.h
+++ b/metrics.h
@@ -6,9 +6,9 @@
 /* linux, freebsd, and netbsd have tcp_info structs.
  * I don't know about other systems so we disable this
  * functionality for them */
-#if defined __linux__ || defined __FreeBSD__ || defined __NetBSD__
+#if (defined __linux__ || defined __FreeBSD__ || defined __NetBSD__) && !defined(__alpine__)
 #define TCP_INFO 1
-#if defined __linux__
+#if defined __linux__ && !defined(__alpine__)
 #include <linux/tcp.h>
 #else
 #include <netinet/tcp.h>


### PR DESCRIPTION
Small update to be able build hpn-ssh metrics.* because of included tcp and stdio libraries. `__alpine__` macro it this case needs to be defined while `./configure` or `make` call with:
```
CFLAGS="-D__alpine__" ./configure
```
Used libraries:
- musl-dev
- linux-headers
- zlib-dev
- openssl-dev