### PR TITLE
Bug restrict window openssh10

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -371,6 +371,11 @@ clean:	regressclean
 	rm -f regress/ecdsa-sha2-*
 	rm -f regress/host.sk-ecdsa-sha2-nistp256@openssh.com
 	rm -f regress/misc/ssh-verify-attestation/ssh-verify-attestation$(EXEEXT)
+	rm -f regress/dbclient.log
+	rm -f regress/finished.?
+	rm -f regress/ssh-proxy.sh
+	rm -rf regress/.ssh
+	rm -f regress/ssh_proxy.sh
 	rm -f regress/misc/ssh-verify-attestation/*.o
 	(cd openbsd-compat && $(MAKE) clean)
 

--- a/cipher.c
+++ b/cipher.c
@@ -582,10 +582,12 @@ cipher_free(struct sshcipher_ctx *cc)
 	 * the ctx it is a part of it doesn't get freed. So...
 	 * cjr 2/7/2023
 	 */
+#if !defined(WITH_OPENSSL3)
 	if (cc->meth_ptr != NULL) {
 		EVP_CIPHER_meth_free((void *)(EVP_CIPHER *)cc->meth_ptr);
 		cc->meth_ptr = NULL;
 	}
+#endif
 #endif
 	freezero(cc, sizeof(*cc));
 }

--- a/compat.c
+++ b/compat.c
@@ -134,30 +134,29 @@ compat_banner(struct ssh *ssh, const char *version)
 			/* Check to see if the remote side is OpenSSH and not HPN */
 			/* TODO: See if we can work this into the new method for bug checks */
 			if (strstr(version, "OpenSSH") != NULL) {
-				if (strstr(version, "hpn")) {
+				/* check if the remote is hpn and if the version
+				 * uses hpn prefixed binaries */
+				const char *op;
+				if ((op = strstr(version, "hpn")) != NULL) {
+					int hpnver = 0;
 					ssh->compat |= SSH_HPNSSH;
 					debug("Remote is HPN enabled");
+					if (sscanf(op, "hpn%d", &hpnver) == 1 &&
+					    hpnver >= 16) {
+						ssh->compat |= SSH_HPNSSH_PREFIX;
+						debug("Remote uses HPNSSH prefixes.");
+					}
 				}
-				/* this checks to see if the remote
-				 * version string indicates that we
-				 * have access to hpn prefixed binaries
-				 * You'll need to change this to include
-				 * new major version numbers. Which is
-				 * why we should figure out how to make
-				 * the match pattern list work
-				 */
-				if ((strstr(version, "hpn16") != NULL) ||
-				    (strstr(version, "hpn17") != NULL) ||
-				    (strstr(version, "hpn18") != NULL)) {
-					ssh->compat |= SSH_HPNSSH_PREFIX;
-					debug("Remote uses HPNSSH prefixes.");
-					break;
-				}
-				/* if it's openssh and not hpn */
-				if ((strstr(version, "OpenSSH_8.9") != NULL) ||
-				    (strstr(version, "OpenSSH_9") != NULL)) {
-					ssh->compat |= SSH_RESTRICT_WINDOW;
-					debug("Restricting adverstised window size.");
+				/* Restrict advertised window for non-HPN OpenSSH >= 8.9. */
+				if (!(ssh->compat & SSH_HPNSSH)) {
+					const char *op;
+					int omaj = 0, omin = 0;
+					if ((op = strstr(version, "OpenSSH_")) != NULL &&
+					    sscanf(op, "OpenSSH_%d.%d", &omaj, &omin) == 2 &&
+					    (omaj >= 9 || (omaj == 8 && omin >= 9))) {
+						ssh->compat |= SSH_RESTRICT_WINDOW;
+						debug("Restricting advertised window size.");
+					}
 				}
 			}
 			debug("ssh->compat is %u", ssh->compat);

--- a/version.h
+++ b/version.h
@@ -3,5 +3,5 @@
 #define SSH_VERSION	"OpenSSH_10.2"
 
 #define SSH_PORTABLE	"p1"
-#define SSH_HPN         "_hpn18.8.0"
+#define SSH_HPN         "_hpn18.8.1"
 #define SSH_RELEASE	SSH_VERSION SSH_PORTABLE SSH_HPN


### PR DESCRIPTION
Updates compat.c to use a more flexible method to determine remote version and set the appropriate flags. Unrelated work is a minor change to Makefile.in to remove more files from regress when executing make clean. 